### PR TITLE
Feature/local storage

### DIFF
--- a/src/app/dashboard/favorites/page.tsx
+++ b/src/app/dashboard/favorites/page.tsx
@@ -1,4 +1,4 @@
-import { PokemonGrid, PokemonsResponse, SimplePokemon } from "@/pokemons";
+import { FavoritePokemons, PokemonGrid, PokemonsResponse, SimplePokemon } from "@/pokemons";
 
 
 export const metadata = {
@@ -7,12 +7,12 @@ export const metadata = {
 };
 
 
-
 export default async function PokemonsPage() {
   return (
     <div className="flex flex-col">
         <span className="text-5xl my-2">Pokemons Favoritos <small className="text-blue-500">Global</small></span>
-        <PokemonGrid pokemons={ [] } />
+        {/*  <PokemonGrid pokemons={ [] } />  */} 
+         <FavoritePokemons /> 
     </div> 
   );
 }

--- a/src/app/dashboard/favorites/page.tsx
+++ b/src/app/dashboard/favorites/page.tsx
@@ -1,4 +1,4 @@
-import { FavoritePokemons, PokemonGrid, PokemonsResponse, SimplePokemon } from "@/pokemons";
+import { FavoritePokemons, PokemonGrid } from "@/pokemons";
 
 
 export const metadata = {

--- a/src/pokemons/components/FavoritePokemons.tsx
+++ b/src/pokemons/components/FavoritePokemons.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import { useAppSelector } from "@/store"
+import { PokemonGrid } from "./PokemonGrid"
+import { useState } from "react";
+import { IoHeadsetOutline } from "react-icons/io5";
+
+export const FavoritePokemons = () => {
+
+    const favoritePokemons = useAppSelector( state => Object.values(state.pokemnos) );
+    const [ pokemons, setPokemons ] = useState( favoritePokemons );
+
+  return (
+    <>
+    {/*<PokemonGrid pokemons={ favoritePokemons } /> */}
+    {
+        pokemons.length === 0
+          ? ( <NoFavorite /> )
+          : (<PokemonGrid pokemons={ pokemons } /> )
+    }
+    </>
+    
+  )
+}
+
+export const NoFavorite = () => {
+    return (
+      <div className="flex flex-col h-[50vh] items-center justify-center">
+        <IoHeadsetOutline size={100} className="text-red-500" />
+        <span>No hay favoritos</span>
+      </div>
+    )
+}

--- a/src/pokemons/components/FavoritePokemons.tsx
+++ b/src/pokemons/components/FavoritePokemons.tsx
@@ -7,16 +7,16 @@ import { IoHeadsetOutline } from "react-icons/io5";
 
 export const FavoritePokemons = () => {
 
-    const favoritePokemons = useAppSelector( state => Object.values(state.pokemnos) );
-    const [ pokemons, setPokemons ] = useState( favoritePokemons );
+    const favoritePokemons = useAppSelector( state => Object.values(state.pokemnos.favorites) );
+    //const [ pokemons, setPokemons ] = useState( favoritePokemons );
 
   return (
     <>
     {/*<PokemonGrid pokemons={ favoritePokemons } /> */}
     {
-        pokemons.length === 0
+        favoritePokemons.length === 0
           ? ( <NoFavorite /> )
-          : (<PokemonGrid pokemons={ pokemons } /> )
+          : (<PokemonGrid pokemons={ favoritePokemons } /> )
     }
     </>
     

--- a/src/pokemons/components/PokemonCard.tsx
+++ b/src/pokemons/components/PokemonCard.tsx
@@ -1,7 +1,11 @@
+"use client"
+
 import Link from "next/link";
 import Image from "next/image";
 import { SimplePokemon } from "../interfaces/simple-pokemon";
-import { IoHeartOutline } from "react-icons/io5";
+import { IoHeart, IoHeartOutline } from "react-icons/io5";
+import { useAppDispatch, useAppSelector } from "@/store";
+import { toggleFavorites } from "@/store/pokemons/pokemons";
 
 interface Props {
   pokemon: SimplePokemon;
@@ -10,6 +14,12 @@ interface Props {
 export const PokemonCard = ({ pokemon }:Props) => {
 
   const { id, name } = pokemon;
+  const isFavorite = useAppSelector(state => !!state.pokemnos[id])
+  const dispatch = useAppDispatch();
+
+  const onToggle = () => {
+    dispatch( toggleFavorites(pokemon) )
+  }
   
   return (
     <div className="mx-auto right-0 mt-2 w-60">
@@ -34,17 +44,26 @@ export const PokemonCard = ({ pokemon }:Props) => {
           </div>
         </div>
         <div className="border-b">
-          <Link href="/dashboard/main" className="px-4 py-2 hover:bg-gray-100 flex items-center">
+          <div onClick={onToggle}
+            className="px-4 py-2 hover:bg-gray-100 flex items-center cursor-pointer">
               <div className="text-red-600">
-                <IoHeartOutline />
+                {
+                  isFavorite
+                  ? ( <IoHeart /> )
+                  : ( <IoHeartOutline /> )
+                } 
               </div>
               <div className="pl-3">
                 <p className="text-sm font-medium text-gray-800 leading-none">
-                  No es favorito
+                  {
+                    isFavorite
+                     ? 'Es favorite'
+                     : 'No es favorito'
+                  }
                 </p>
-                <p className="text-xs text-gray-500">View your campaigns</p>
+                <p className="text-xs text-gray-500">Click para cambiar</p>
               </div>
-          </Link>
+          </div>
         </div>
       </div>
     </div>

--- a/src/pokemons/components/PokemonCard.tsx
+++ b/src/pokemons/components/PokemonCard.tsx
@@ -14,7 +14,7 @@ interface Props {
 export const PokemonCard = ({ pokemon }:Props) => {
 
   const { id, name } = pokemon;
-  const isFavorite = useAppSelector(state => !!state.pokemnos[id])
+  const isFavorite = useAppSelector(state => !!state.pokemnos.favorites[id])
   const dispatch = useAppDispatch();
 
   const onToggle = () => {

--- a/src/pokemons/index.ts
+++ b/src/pokemons/index.ts
@@ -1,4 +1,6 @@
+
 export { PokemonGrid } from './components/PokemonGrid';
+export { FavoritePokemons } from './components/FavoritePokemons';
 
 export type { PokemonsResponse } from './interfaces/pokemons-response';
 export type { SimplePokemon } from './interfaces/simple-pokemon';

--- a/src/store/Providers.tsx
+++ b/src/store/Providers.tsx
@@ -2,15 +2,28 @@
 
 import { Provider } from 'react-redux';
 import { store } from './index';
+import { useEffect } from 'react';
+import { setFavoritePokemons } from './pokemons/pokemons';
 
 interface Props {
     children: React.ReactNode;
 }
 
 export const Providers = ({children}: Props) => {
+
+  useEffect(() => {
+    const favorites = JSON.parse( localStorage.getItem('favorite-pokemons') ?? '{}' )
+    store.dispatch(setFavoritePokemons(favorites));
+  }, [])
+
+
   return (
     <Provider store={ store }>
         {children}
     </Provider>
   )
 }
+function dispatch(arg0: { payload: { [key: string]: import("../pokemons").SimplePokemon; }; type: "pokemons/setFavoritePokemons"; }) {
+  throw new Error('Function not implemented.');
+}
+

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,11 +1,13 @@
 import { configureStore } from '@reduxjs/toolkit'
 
 import counterReducer from './counter/counterSlice';
+import pokemonsReducer from './pokemons/pokemons';
 import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux';
 
 export const store = configureStore({
   reducer: {
     counter: counterReducer,
+    pokemnos: pokemonsReducer,
   },
 })
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -10,8 +10,8 @@ export const store = configureStore({
     counter: counterReducer,
     pokemnos: pokemonsReducer,
   },
-  middleware: ( getDefaultMiddleware ) => getDefaultMiddleware()
-    .concat( localStorageMiddleware )
+  //middleware: ( getDefaultMiddleware ) => getDefaultMiddleware()
+   // .concat( localStorageMiddleware )
 })
 
 // Infer the `RootState` and `AppDispatch` types from the store itself

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -3,12 +3,15 @@ import { configureStore } from '@reduxjs/toolkit'
 import counterReducer from './counter/counterSlice';
 import pokemonsReducer from './pokemons/pokemons';
 import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux';
+import { localStorageMiddleware } from './middlewares/localstorage-middleware';
 
 export const store = configureStore({
   reducer: {
     counter: counterReducer,
     pokemnos: pokemonsReducer,
   },
+  middleware: ( getDefaultMiddleware ) => getDefaultMiddleware()
+    .concat( localStorageMiddleware )
 })
 
 // Infer the `RootState` and `AppDispatch` types from the store itself

--- a/src/store/middlewares/localstorage-middleware.ts
+++ b/src/store/middlewares/localstorage-middleware.ts
@@ -1,0 +1,15 @@
+import { Action, Dispatch, MiddlewareAPI } from "@reduxjs/toolkit";
+import { RootState } from "..";
+
+export const localStorageMiddleware = ( state: MiddlewareAPI ) => {
+    return (next: Dispatch) => (action: Action) => {
+        next(action);
+        if ( action.type === 'pokemons/toggleFavorite' ) {
+            const { pokemons } = state.getState() as RootState;
+            localStorage.setItem('favorite-pokemons', JSON.stringify(pokemons));
+            return;
+        }
+
+
+    }
+}

--- a/src/store/pokemons/pokemons.ts
+++ b/src/store/pokemons/pokemons.ts
@@ -7,7 +7,8 @@ interface PokemonsState {
 
 const initialState: PokemonsState = {
     '1': { id: '1', name: 'bulbasaur'},
-    '3': { id: '3', name: 'ajkjakjsd'},
+    '3': { id: '3', name: 'venusaur'},
+    '5': { id: '5', name: 'charmeleon'},
 }
 
 const pokemonsSlice = createSlice({

--- a/src/store/pokemons/pokemons.ts
+++ b/src/store/pokemons/pokemons.ts
@@ -1,5 +1,5 @@
 import { SimplePokemon } from '@/pokemons';
-import { createSlice } from '@reduxjs/toolkit'
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 
 interface PokemonsState {
     [key: string]: SimplePokemon,
@@ -7,14 +7,26 @@ interface PokemonsState {
 
 const initialState: PokemonsState = {
     '1': { id: '1', name: 'bulbasaur'},
+    '3': { id: '3', name: 'ajkjakjsd'},
 }
 
 const pokemonsSlice = createSlice({
   name: 'pokemons',
   initialState,
-  reducers: {}
+  reducers: {
+    toggleFavorites( state, action: PayloadAction<SimplePokemon> ) {
+        const pokemon = action.payload;
+        const {id} = pokemon;
+        
+        if ( !!state[id] ) {
+            delete state[id];
+            return;
+        }
+        state[id] = pokemon;
+    }
+  }
 });
 
-export const {} = pokemonsSlice.actions;
+export const { toggleFavorites } = pokemonsSlice.actions;
 
 export default pokemonsSlice.reducer;

--- a/src/store/pokemons/pokemons.ts
+++ b/src/store/pokemons/pokemons.ts
@@ -5,10 +5,16 @@ interface PokemonsState {
     [key: string]: SimplePokemon,
 }
 
+const getInitialState = (): PokemonsState => {
+  const favorites = JSON.parse( localStorage.getItem('favorite-pokemons') ?? '{}' )
+  return favorites;
+}
+
 const initialState: PokemonsState = {
-    '1': { id: '1', name: 'bulbasaur'},
-    '3': { id: '3', name: 'venusaur'},
-    '5': { id: '5', name: 'charmeleon'},
+  ...getInitialState()
+    //'1': { id: '1', name: 'bulbasaur'},
+    //'3': { id: '3', name: 'venusaur'},
+    //'5': { id: '5', name: 'charmeleon'},
 }
 
 const pokemonsSlice = createSlice({
@@ -21,9 +27,14 @@ const pokemonsSlice = createSlice({
         
         if ( !!state[id] ) {
             delete state[id];
-            return;
+            //return;
+        } else {
+          state[id] = pokemon;
         }
-        state[id] = pokemon;
+        
+        //Todo: no se debe hacer en Redux
+        localStorage.setItem('favorite-pokemons', JSON.stringify(state));
+        
     }
   }
 });

--- a/src/store/pokemons/pokemons.ts
+++ b/src/store/pokemons/pokemons.ts
@@ -1,0 +1,20 @@
+import { SimplePokemon } from '@/pokemons';
+import { createSlice } from '@reduxjs/toolkit'
+
+interface PokemonsState {
+    [key: string]: SimplePokemon,
+}
+
+const initialState: PokemonsState = {
+    '1': { id: '1', name: 'bulbasaur'},
+}
+
+const pokemonsSlice = createSlice({
+  name: 'pokemons',
+  initialState,
+  reducers: {}
+});
+
+export const {} = pokemonsSlice.actions;
+
+export default pokemonsSlice.reducer;

--- a/src/store/pokemons/pokemons.ts
+++ b/src/store/pokemons/pokemons.ts
@@ -2,16 +2,20 @@ import { SimplePokemon } from '@/pokemons';
 import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 
 interface PokemonsState {
-    [key: string]: SimplePokemon,
+  favorites: {[key: string]: SimplePokemon},
 }
 
-const getInitialState = (): PokemonsState => {
+/*const getInitialState = (): PokemonsState => {
+
+  //if (typeof localStorage === 'undefined') return {};
+
   const favorites = JSON.parse( localStorage.getItem('favorite-pokemons') ?? '{}' )
   return favorites;
-}
+}*/
 
 const initialState: PokemonsState = {
-  ...getInitialState()
+    favorites: {},
+    //...getInitialState()
     //'1': { id: '1', name: 'bulbasaur'},
     //'3': { id: '3', name: 'venusaur'},
     //'5': { id: '5', name: 'charmeleon'},
@@ -21,24 +25,28 @@ const pokemonsSlice = createSlice({
   name: 'pokemons',
   initialState,
   reducers: {
+    setFavoritePokemons( state, action: PayloadAction<{[key: string]: SimplePokemon}> ) {
+        state.favorites = action.payload;
+    },
+
     toggleFavorites( state, action: PayloadAction<SimplePokemon> ) {
         const pokemon = action.payload;
         const {id} = pokemon;
         
-        if ( !!state[id] ) {
-            delete state[id];
+        if ( !!state.favorites[id] ) {
+            delete state.favorites[id];
             //return;
         } else {
-          state[id] = pokemon;
+          state.favorites[id] = pokemon;
         }
         
         //Todo: no se debe hacer en Redux
-        localStorage.setItem('favorite-pokemons', JSON.stringify(state));
+        localStorage.setItem('favorite-pokemons', JSON.stringify(state.favorites));
         
     }
   }
 });
 
-export const { toggleFavorites } = pokemonsSlice.actions;
+export const { toggleFavorites, setFavoritePokemons } = pokemonsSlice.actions;
 
 export default pokemonsSlice.reducer;


### PR DESCRIPTION
# Feature/local-storage

## Description

This pull request implements a local storage feature to persist users' favorite Pokémon selections in a React + Redux application. By utilizing `localStorage`, the favorites list remains accessible even after the user refreshes or closes the browser. Key components and changes include the following:

### Key Updates

1. **State Management with Redux Toolkit**:
   - Defined a `PokemonsState` interface, with a `favorites` property to store Pokémon data indexed by Pokémon IDs.
   - Created a slice named `pokemons` with initial state and reducers (`setFavoritePokemons` and `toggleFavorites`).
   - **Reducers**:
     - **`setFavoritePokemons`**: Sets the `favorites` state with a payload containing Pokémon data from local storage.
     - **`toggleFavorites`**: Toggles Pokémon in and out of the favorites list by adding or deleting entries in the `favorites` object. Also updates local storage directly within the reducer, though this is generally avoided in Redux (see note below).

2. **Local Storage Management**:
   - Stored Pokémon favorites list in `localStorage` with `localStorage.setItem('favorite-pokemons', JSON.stringify(state.favorites))` inside the `toggleFavorites` reducer.
   - Added `useEffect` in the `Providers` component to initialize `favorites` from local storage on load. This ensures that the stored favorites are reloaded into the app's state each time the app starts.

3. **Components**:
   - **FavoritePokemons**: Uses the `useAppSelector` hook to retrieve the favorite Pokémon list from the Redux store. Renders a Pokémon grid if there are favorites or displays a fallback (`NoFavorite`) component otherwise.
   - **NoFavorite**: A simple placeholder component displaying a message and an icon if there are no favorites stored.
   - **Providers Component**: Wraps the app's components with Redux `Provider`. It dispatches the `setFavoritePokemons` action on mount to load initial state from `localStorage`.

4. **Store and Middleware Configuration**:
   - Configured the Redux store to include `pokemonsReducer` alongside an existing `counterReducer`.
   - **`localStorageMiddleware`**: Although currently commented out, this middleware could be activated to synchronize local storage updates without handling side effects directly in reducers.

### Important Notes

- **Avoiding Side Effects in Reducers**: Direct manipulation of `localStorage` within a reducer (`toggleFavorites`) is generally discouraged. Middleware could be used in future iterations to separate local storage handling from state logic.
  
### How to Test

1. Add Pokémon to the favorites list and verify that they persist in local storage.
2. Refresh the page to ensure that favorites are reloaded correctly.
3. Remove Pokémon from the favorites list and confirm that they are also removed from local storage.

### Files Modified

- `pokemons/pokemons.ts`: Added `pokemonsSlice` with `setFavoritePokemons` and `toggleFavorites` reducers.
- `FavoritePokemons.tsx`: Displays favorite Pokémon or fallback message.
- `Providers.tsx`: Dispatches `setFavoritePokemons` on load to initialize state from local storage.
- `store/index.ts`: Configured Redux store with `pokemonsReducer` and commented `localStorageMiddleware`.